### PR TITLE
Casting improvement

### DIFF
--- a/source/tlang/testing/simple_cast_complex_type.t
+++ b/source/tlang/testing/simple_cast_complex_type.t
@@ -1,0 +1,9 @@
+module simple_cast_complex_type;
+
+int myInt;
+
+void function(int x)
+{
+    byte bruh;
+    byte myByte = (cast(byte)int*)+bruh;
+}


### PR DESCRIPTION
We can make casting work on any type sequence (multiple tokens) by making clever use of `parseTypedDeclaration()`.

See [this](https://deavmi.assigned.network/git/tlang/tlang/issues/110#issuecomment-1148).