### PR TITLE
🐞️ Bugfix: Function parameter types should use parseTypedDeclaration(onlyType=true)

### DIFF
--- a/source/tlang/compiler/parsing/core.d
+++ b/source/tlang/compiler/parsing/core.d
@@ -910,14 +910,6 @@ public final class Parser
                 TypedEntity bogusEntity = parseTypedDeclaration(false, false, false, true);
                 string type = bogusEntity.getType();
 
-                // /* If it is a star `*` */
-                // while(getSymbolType(getCurrentToken()) == SymbolType.STAR)
-                // {
-                //     // Make type a pointer
-                //     type = type~"*";
-                //     nextToken();
-                // }
-
                 /* Get the identifier (This CAN NOT be dotted) */
                 expect(SymbolType.IDENT_TYPE, getCurrentToken());
                 if(!isIdentifier_NoDot(getCurrentToken()))


### PR DESCRIPTION
See [this](https://deavmi.assigned.network/git/tlang/tlang/issues/111) issue.